### PR TITLE
feat: Header에서 nav 연결을 마무리합니다.

### DIFF
--- a/src/components/Layout/Footer/Footer.styles.ts
+++ b/src/components/Layout/Footer/Footer.styles.ts
@@ -3,8 +3,8 @@ import { FlexAlignCSS, FlexColumnCSS } from '@/styles'
 import styled from 'styled-components'
 
 export const Footer = styled.footer`
-  position: fixed;
-  bottom: 0;
+  position: absolute;
+  z-index: 4;
   width: 100vw;
   height: 30rem;
   background-color: ${({ theme }) => theme.COLOR.common.black};

--- a/src/components/Layout/Header/Header.styles.ts
+++ b/src/components/Layout/Header/Header.styles.ts
@@ -10,6 +10,7 @@ export const HeaderContainer = styled.header`
   top: 0%;
   color: ${({ theme }) => theme.COLOR.common.white};
   background-color: ${({ theme }) => theme.COLOR.common.black};
+  z-index: 2;
 `
 
 // Logo 와 NavBar 를 감싼 영역

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -1,25 +1,27 @@
+import { MainNav } from '@/constants'
+import { useLocation, useNavigate } from 'react-router-dom'
 import * as S from './Header.styles'
-
-import { useState } from 'react'
-
 export const Header: React.FC = () => {
-  const NavigationFilter = ['홈', '뉴스', '테크위키', '게임', '갤러리']
-  const [activeNavItem, setActiveNavItem] = useState(0)
+  const { pathname } = useLocation()
+  const navigate = useNavigate()
+
+  const handleNav = (path: `/${string}`) => {
+    navigate(path)
+  }
+
   return (
     <>
       <S.HeaderContainer>
         <S.LogoAndNavWrapper>
           <S.LogoIMG src="assets/logo/logo_512x105.svg" />
           <S.NavList>
-            {NavigationFilter.map((item, index) => (
+            {MainNav.map((item, index) => (
               <S.NavItem
-                onClick={() => {
-                  setActiveNavItem(index)
-                }}
-                $isActive={index === activeNavItem}
-                key={item}
+                onClick={() => handleNav(item.path)}
+                $isActive={pathname === MainNav[index].path}
+                key={item.text}
               >
-                {item}
+                {item.text}
               </S.NavItem>
             ))}
           </S.NavList>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './mainNav'

--- a/src/constants/mainNav.ts
+++ b/src/constants/mainNav.ts
@@ -1,0 +1,22 @@
+export const MainNav = [
+  {
+    path: '/',
+    text: '홈',
+  },
+  {
+    path: '/news',
+    text: '뉴스',
+  },
+  {
+    path: '/tech-wiki',
+    text: '테크위키',
+  },
+  {
+    path: '/game',
+    text: '게임',
+  },
+  {
+    path: '/gallery',
+    text: '갤러리',
+  },
+] as const

--- a/src/pages/Game/index.tsx
+++ b/src/pages/Game/index.tsx
@@ -1,5 +1,5 @@
-const GamePage = () => {
-  return <h1>GamePage</h1>
+const GameMainPage = () => {
+  return <h1>GameMainPage</h1>
 }
 
-export default GamePage
+export default GameMainPage

--- a/src/routes/routing.tsx
+++ b/src/routes/routing.tsx
@@ -1,6 +1,6 @@
 import { Layout } from '@/components'
 import GalleryPage from '@/pages/Gallery'
-import GamePage from '@/pages/Game'
+import GameMainPage from '@/pages/Game'
 import MainPage from '@/pages/Main'
 import NewsPage from '@/pages/News'
 import TechWikiPage from '@/pages/Tech-wiki'
@@ -28,8 +28,8 @@ export const routers = createBrowserRouter([
         element: <GalleryPage />,
       },
       {
-        path: '/game/:category',
-        element: <GamePage />,
+        path: '/game',
+        element: <GameMainPage />,
       },
     ],
   },


### PR DESCRIPTION
## 이슈 번호

#20  

## 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 기타

## 작업 상세 내용

Header에 존재하는 navigation에 각 컴포넌트를 링크로 연결했습니다.
기존에 state로 관리되던 현재 nav를 react 내장 훅 함수를 이용하여 표시 방법을 변경했습니다.

![koosmoos_1](https://github.com/2023-chambit-project/KOOSMOOS/assets/112946860/17d71543-9c1e-4962-80f1-b977d6596145)


## 다음 할 일

## 체크 리스트
- [x] main 브랜치 pull 받기
- [x] 아직 작업 중인 파일은 올리지 않기

## 질문 사항

💬 **질문이 있어요!**

🔴 **이건 반드시 확인해 주세요!**

@TransparentDeveloper 윤신님! 기존에 `/game/:category`로 라우팅 미리 세팅해두었던 것 지웠습니다.
그 이유는 우선 `/game`이라는 페이지에는 게임 페이지의 메인이 와야할 것 같고, 그 다음 depth로 오게 될 각각 게임 페이지는 윤신님께서 추가로 라우팅 이름 지어서 설정해주시면 될 것 같아서입니다!