### PR TITLE
#3 공용 컴포넌트 중 Button 디자인 수정한 버전을 추가했습니다.

### DIFF
--- a/src/components/ButtonV2/ButtonV2.styles.ts
+++ b/src/components/ButtonV2/ButtonV2.styles.ts
@@ -49,7 +49,6 @@ export const ButtonV2 = styled.button<StyleProps>`
   gap: 1rem;
   font-size: ${({ theme }) => theme.FONT_SIZE.small};
   height: 5rem;
-  min-height: 40px;
 
   ${({ variant = 'default' }) => variantCSS[variant]}
   ${({ size = 'default' }) => sizeCSS[size]}

--- a/src/components/ButtonV2/ButtonV2.styles.ts
+++ b/src/components/ButtonV2/ButtonV2.styles.ts
@@ -23,13 +23,13 @@ export const sizeCSS = {
 }
 export const roundCSS = {
   default: css`
-    border-radius: 0.5rem;
+    border-radius: 8px;
   `,
   slightly: css`
-    border-radius: 2rem;
+    border-radius: 15px;
   `,
   very: css`
-    border-radius: 100rem;
+    border-radius: 30px;
   `,
 }
 export const skinCSS = {

--- a/src/components/ButtonV2/ButtonV2.styles.ts
+++ b/src/components/ButtonV2/ButtonV2.styles.ts
@@ -50,7 +50,6 @@ export const ButtonV2 = styled.button<StyleProps>`
   height: 5rem;
   min-height: 40px;
   padding: 0.5rem 1rem;
-  margin: 0.5rem;
 
   ${({ variant = 'default' }) => variantCSS[variant]};
   ${({ size = 'default' }) => sizeCSS[size]};

--- a/src/components/ButtonV2/ButtonV2.styles.ts
+++ b/src/components/ButtonV2/ButtonV2.styles.ts
@@ -11,7 +11,7 @@ export const variantCSS = {
 }
 export const sizeCSS = {
   default: css`
-    width: 15rem;
+    width: 17rem;
   `,
   fit: css`
     width: fit-content;
@@ -23,13 +23,13 @@ export const sizeCSS = {
 }
 export const roundCSS = {
   default: css`
-    border-radius: 10px;
+    border-radius: 0.5rem;
   `,
   slightly: css`
-    border-radius: 20px;
+    border-radius: 2rem;
   `,
   very: css`
-    border-radius: 100px;
+    border-radius: 100rem;
   `,
 }
 export const skinCSS = {
@@ -39,7 +39,6 @@ export const skinCSS = {
 
     &:hover {
       color: ${({ theme }) => theme.COLOR.common.black};
-      border-color: ${({ theme }) => theme.COLOR.common.black};
     }
   `,
   dark: css`
@@ -48,7 +47,6 @@ export const skinCSS = {
 
     &:hover {
       color: ${({ theme }) => theme.COLOR.common.white};
-      border-color: ${({ theme }) => theme.COLOR.common.white};
     }
   `,
 }
@@ -56,15 +54,19 @@ export const skinCSS = {
 export const ButtonV2 = styled.button<StyleProps>`
   ${FlexCenterCSS}
   gap: 1rem;
-
+  font-size: ${({ theme }) => theme.FONT_SIZE.small};
   height: 5rem;
-  padding: 1rem;
+  min-height: 40px;
+  padding: 0.5rem 1rem;
+  margin: 0.5rem;
+
   ${({ variant = 'default' }) => variantCSS[variant]};
   ${({ size = 'default' }) => sizeCSS[size]};
   ${({ round = 'default' }) => roundCSS[round]};
   ${({ skin = 'default' }) => skinCSS[skin]}
   background-color: ${({ idleBgColor }) => idleBgColor};
   &:hover {
+    border: none;
     background-color: ${({ hoverBgColor }) => hoverBgColor};
     transition: background-color 0.3s ease;
   }

--- a/src/components/ButtonV2/ButtonV2.styles.ts
+++ b/src/components/ButtonV2/ButtonV2.styles.ts
@@ -16,6 +16,7 @@ export const sizeCSS = {
   fit: css`
     width: fit-content;
     height: fit-content;
+    padding: 0.5rem 1rem;
   `,
   full: css`
     width: 100%;
@@ -49,11 +50,10 @@ export const ButtonV2 = styled.button<StyleProps>`
   font-size: ${({ theme }) => theme.FONT_SIZE.small};
   height: 5rem;
   min-height: 40px;
-  padding: 0.5rem 1rem;
 
-  ${({ variant = 'default' }) => variantCSS[variant]};
-  ${({ size = 'default' }) => sizeCSS[size]};
-  ${({ round = 'default' }) => roundCSS[round]};
+  ${({ variant = 'default' }) => variantCSS[variant]}
+  ${({ size = 'default' }) => sizeCSS[size]}
+  ${({ round = 'default' }) => roundCSS[round]}
   ${({ skin = 'default' }) => skinCSS[skin]}
   background-color: ${({ bgColor, theme }) => (bgColor ? bgColor : theme.COLOR.common.gray[900])};
 

--- a/src/components/ButtonV2/ButtonV2.styles.ts
+++ b/src/components/ButtonV2/ButtonV2.styles.ts
@@ -1,0 +1,74 @@
+import { FlexCenterCSS } from '@/styles'
+import styled, { css } from 'styled-components'
+import type { StyleProps } from './ButtonV2.types'
+
+export const variantCSS = {
+  default: css``,
+  outlined: css`
+    border-width: 1px;
+    border-style: solid;
+  `,
+}
+export const sizeCSS = {
+  default: css`
+    width: 15rem;
+  `,
+  fit: css`
+    width: fit-content;
+    height: fit-content;
+  `,
+  full: css`
+    width: 100%;
+  `,
+}
+export const roundCSS = {
+  default: css`
+    border-radius: 10px;
+  `,
+  slightly: css`
+    border-radius: 20px;
+  `,
+  very: css`
+    border-radius: 100px;
+  `,
+}
+export const skinCSS = {
+  default: css`
+    color: ${({ theme }) => theme.COLOR.common.white};
+    border-color: ${({ theme }) => theme.COLOR.common.white};
+
+    &:hover {
+      color: ${({ theme }) => theme.COLOR.common.black};
+      border-color: ${({ theme }) => theme.COLOR.common.black};
+    }
+  `,
+  dark: css`
+    color: ${({ theme }) => theme.COLOR.common.black};
+    border-color: ${({ theme }) => theme.COLOR.common.black};
+
+    &:hover {
+      color: ${({ theme }) => theme.COLOR.common.white};
+      border-color: ${({ theme }) => theme.COLOR.common.white};
+    }
+  `,
+}
+
+export const ButtonV2 = styled.button<StyleProps>`
+  ${FlexCenterCSS}
+  gap: 1rem;
+
+  height: 5rem;
+  padding: 1rem;
+  ${({ variant = 'default' }) => variantCSS[variant]};
+  ${({ size = 'default' }) => sizeCSS[size]};
+  ${({ round = 'default' }) => roundCSS[round]};
+  ${({ skin = 'default' }) => skinCSS[skin]}
+  background-color: ${({ idleBgColor }) => idleBgColor};
+  &:hover {
+    background-color: ${({ hoverBgColor }) => hoverBgColor};
+    transition: background-color 0.3s ease;
+  }
+  white-space: nowrap;
+  overflow: hidden;
+  cursor: pointer;
+`

--- a/src/components/ButtonV2/ButtonV2.styles.ts
+++ b/src/components/ButtonV2/ButtonV2.styles.ts
@@ -36,18 +36,10 @@ export const skinCSS = {
   default: css`
     color: ${({ theme }) => theme.COLOR.common.white};
     border-color: ${({ theme }) => theme.COLOR.common.white};
-
-    &:hover {
-      color: ${({ theme }) => theme.COLOR.common.black};
-    }
   `,
   dark: css`
     color: ${({ theme }) => theme.COLOR.common.black};
     border-color: ${({ theme }) => theme.COLOR.common.black};
-
-    &:hover {
-      color: ${({ theme }) => theme.COLOR.common.white};
-    }
   `,
 }
 
@@ -64,12 +56,15 @@ export const ButtonV2 = styled.button<StyleProps>`
   ${({ size = 'default' }) => sizeCSS[size]};
   ${({ round = 'default' }) => roundCSS[round]};
   ${({ skin = 'default' }) => skinCSS[skin]}
-  background-color: ${({ idleBgColor }) => idleBgColor};
+  background-color: ${({ bgColor, theme }) => (bgColor ? bgColor : theme.COLOR.common.gray[900])};
+
   &:hover {
-    border: none;
-    background-color: ${({ hoverBgColor }) => hoverBgColor};
-    transition: background-color 0.3s ease;
+    box-shadow:
+      inset 0 2px 20px rgba(0, 0, 0, 0.2),
+      0 2px 20px rgba(0, 0, 0, 0.2);
   }
+  transition: box-shadow 0.3s ease;
+
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;

--- a/src/components/ButtonV2/ButtonV2.styles.ts
+++ b/src/components/ButtonV2/ButtonV2.styles.ts
@@ -37,10 +37,21 @@ export const skinCSS = {
   default: css`
     color: ${({ theme }) => theme.COLOR.common.white};
     border-color: ${({ theme }) => theme.COLOR.common.white};
+
+    &:hover {
+      color: ${({ theme }) => theme.COLOR.common.black};
+      border-color: ${({ theme }) => theme.COLOR.common.black};
+      background-color: ${({ theme }) => theme.COLOR.common.white};
+    }
   `,
   dark: css`
     color: ${({ theme }) => theme.COLOR.common.black};
     border-color: ${({ theme }) => theme.COLOR.common.black};
+    &:hover {
+      color: ${({ theme }) => theme.COLOR.common.white};
+      border-color: ${({ theme }) => theme.COLOR.common.white};
+      background-color: ${({ theme }) => theme.COLOR.common.black};
+    }
   `,
 }
 
@@ -56,12 +67,10 @@ export const ButtonV2 = styled.button<StyleProps>`
   ${({ skin = 'default' }) => skinCSS[skin]}
   background-color: ${({ bgColor, theme }) => (bgColor ? bgColor : theme.COLOR.common.gray[900])};
 
-  &:hover {
-    box-shadow:
-      inset 0 2px 20px rgba(0, 0, 0, 0.2),
-      0 2px 20px rgba(0, 0, 0, 0.2);
-  }
-  transition: box-shadow 0.3s ease;
+  transition:
+    color 0.1s ease,
+    background-color 0.2s ease,
+    border-color 0.3s ease;
 
   white-space: nowrap;
   overflow: hidden;

--- a/src/components/ButtonV2/ButtonV2.styles.ts
+++ b/src/components/ButtonV2/ButtonV2.styles.ts
@@ -5,7 +5,7 @@ import type { StyleProps } from './ButtonV2.types'
 export const variantCSS = {
   default: css``,
   outlined: css`
-    border-width: 1px;
+    border-width: 0.2rem;
     border-style: solid;
   `,
 }

--- a/src/components/ButtonV2/ButtonV2.types.ts
+++ b/src/components/ButtonV2/ButtonV2.types.ts
@@ -5,5 +5,5 @@ export interface StyleProps {
   size?: keyof typeof sizeCSS
   round?: keyof typeof roundCSS
   skin?: keyof typeof skinCSS
-  idleBgColor?: string
+  bgColor?: string
 }

--- a/src/components/ButtonV2/ButtonV2.types.ts
+++ b/src/components/ButtonV2/ButtonV2.types.ts
@@ -5,6 +5,5 @@ export interface StyleProps {
   size?: keyof typeof sizeCSS
   round?: keyof typeof roundCSS
   skin?: keyof typeof skinCSS
-  idleBgColor: string
-  hoverBgColor: string
+  idleBgColor?: string
 }

--- a/src/components/ButtonV2/ButtonV2.types.ts
+++ b/src/components/ButtonV2/ButtonV2.types.ts
@@ -1,0 +1,10 @@
+import { roundCSS, sizeCSS, skinCSS, variantCSS } from './ButtonV2.styles'
+
+export interface StyleProps {
+  variant?: keyof typeof variantCSS
+  size?: keyof typeof sizeCSS
+  round?: keyof typeof roundCSS
+  skin?: keyof typeof skinCSS
+  idleBgColor: string
+  hoverBgColor: string
+}

--- a/src/components/ButtonV2/index.tsx
+++ b/src/components/ButtonV2/index.tsx
@@ -1,0 +1,18 @@
+import { IconProp } from '@fortawesome/fontawesome-svg-core'
+import { FC, HTMLAttributes, PropsWithChildren } from 'react'
+import { Icon } from '../Icon'
+import * as S from './ButtonV2.styles'
+import type { StyleProps } from './ButtonV2.types'
+
+interface Props extends HTMLAttributes<HTMLButtonElement>, StyleProps {
+  icon?: IconProp
+}
+
+export const ButtonV2: FC<PropsWithChildren<Props>> = ({ children, icon, ...props }) => {
+  return (
+    <S.ButtonV2 {...props}>
+      {children}
+      {icon && <Icon icon={icon} color="none" />}
+    </S.ButtonV2>
+  )
+}


### PR DESCRIPTION
## 이슈 번호
#3

## 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 기타

## 작업 상세 내용
- Button2 컴포넌트 작성
- props 정의
  - `icon` : 아이콘 데이터
  - `variant : { "default" | "outlined" }` : 버튼의 외곽선 여부
  - `size : { "default" | "fit" | "full" }` : 버튼의 크기
  - `round : { "default" | "slightly" | "very" }` : 둥긂 정도
  - `skin : { "default" | "light" }` : 폰트, 아이콘, 외곽선 색상
  - `idleBgColor : string` : 버튼의 기본 배경 색상
  - `hoverBgColor : string` : 호버 시 버튼의 배경 색상


## 다음 할 일

## 체크 리스트
- [x] main 브랜치 pull 받기
- [x] 아직 작업 중인 파일은 올리지 않기

## 질문 사항

💬 **질문이 있어요!**

🔴 **이건 반드시 확인해 주세요!**
- 기존 Button 컴포넌트를 삭제하지 않았습니다.!
- 기존 Button 과 달리 배경 색상을 마음대로 지정할 수 있습니다.
  + ⚠️ idleBgColor, hoverBgColor 속성 값은 반드시 필요합니다. 
  
  
![ButtonV2](https://github.com/2023-chambit-project/KOOSMOOS/assets/50646145/5f668e96-b123-45a0-b9fd-56364030ef75)
